### PR TITLE
Handle HTTP status code 403

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -348,7 +348,7 @@ Client.prototype.fetch = function (path, params, cb) {
     })
 
     request.on('response', function (response) {
-      if (response.statusCode !== 200) {
+      if (response.statusCode !== 200 && response.statusCode !== 403) {
         var err = new Error('Unsupported HTTP response: ' + response.statusCode)
         err.response = response
         cb(err)


### PR DESCRIPTION
The API responds with HTTP status code 403 upon authentication failure or when a key has expired.

Auth failure: https://api.eveonline.com/account/APIKeyInfo.xml.aspx?keyID=1
Expired: https://api.eveonline.com/account/APIKeyInfo.xml.aspx?keyID=2048

This would previously always cause eveonlinejs to report an `Unsupported HTTP response: 403` error.

This commit instead lets [the parser](https://github.com/MichaelErmer/eveonlinejs/blob/master/lib/client.js#L253) handle the error, which provides more useful error messages.
See: http://wiki.eve-id.net/APIv2_Eve_ErrorList_XML

NB: this almost certainly qualifies as an _incompatible API change_ as defined by [semver](http://semver.org/), and if accepted, will require a major version increment before publishing.
