### PR TITLE
Add rate-limiter

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -4,6 +4,7 @@ var url = require('url')
   , querystring = require('querystring')
   , sax = require('sax')
   , MemoryCache = require('./cache/memory')
+  , RateLimiter = require('./ratelimiter')
 
 module.exports = Client
 
@@ -14,6 +15,7 @@ module.exports = Client
  * <ul>
  *   <li><strong>url</strong>: Fully qualified HTTP(s) URL to EVE API server</li>
  *   <li><strong>cache</strong>: Cache object that handles persisting and retrieving results from cache</li>
+ *   <li><strong>rateLimit</strong>: Maximum number of requests per second to send to the EVE API server. If set to 0, no limit. Defaults to 30.</li>
  * </ul>
  *
  * @exports Client as eveonline.Client
@@ -24,6 +26,12 @@ module.exports = Client
 function Client(options) {
   options = options || {}
   this._params = {}
+  // Per https://eveonline-third-party-documentation.readthedocs.org/en/latest/xmlapi/intro/#rate-limits
+  var rateLimit = (options.rateLimit == null ? 30 : options.rateLimit)
+  if (rateLimit)
+    this.rateLimiter = new RateLimiter({ perSecond: 30 })
+  else
+    this.rateLimiter = { enqueue: setTimeout }
 
   this.setUrl(options.url || 'https://api.eveonline.com')
   this.setParams(options.params || {})
@@ -338,34 +346,36 @@ Client.prototype.fetch = function (path, params, cb) {
     if (err) return cb(err)
     if (typeof value === 'string') return cb(null, JSON.parse(value))
 
-    var httpObj = options.protocol === 'https:' ? https : http
-      , request = httpObj.get(options)
+    self.rateLimiter.enqueue(function() {
+      var httpObj = options.protocol === 'https:' ? https : http
+        , request = httpObj.get(options)
 
-    options.headers = {'User-Agent': 'eveonline.js'}
+      options.headers = {'User-Agent': 'eveonline.js'}
 
-    request.on('error', function (err) {
-      cb(err)
-    })
-
-    request.on('response', function (response) {
-      if (response.statusCode !== 200) {
-        var err = new Error('Unsupported HTTP response: ' + response.statusCode)
-        err.response = response
+      request.on('error', function (err) {
         cb(err)
-      } else {
-        self.parse(response, function (err, result) {
-          if (err) return cb(err)
+      })
 
-          var currentTime = Date.parse(result.currentTime)
-            , cachedUntil = Date.parse(result.cachedUntil)
-            , duration = cachedUntil - currentTime
-
-          cache.write(cacheKey, JSON.stringify(result), duration, function (err) {
+      request.on('response', function (response) {
+        if (response.statusCode !== 200) {
+          var err = new Error('Unsupported HTTP response: ' + response.statusCode)
+          err.response = response
+          cb(err)
+        } else {
+          self.parse(response, function (err, result) {
             if (err) return cb(err)
-            cb(null, result)
+
+            var currentTime = Date.parse(result.currentTime)
+              , cachedUntil = Date.parse(result.cachedUntil)
+              , duration = cachedUntil - currentTime
+
+            cache.write(cacheKey, JSON.stringify(result), duration, function (err) {
+              if (err) return cb(err)
+              cb(null, result)
+            })
           })
-        })
-      }
+        }
+      })
     })
   })
 }

--- a/lib/ratelimiter.js
+++ b/lib/ratelimiter.js
@@ -1,0 +1,62 @@
+/**
+ * Generic rate-limiter.
+ *
+ * The following list of options are recognized:
+ * <ul>
+ *   <li><strong>perSecond</strong>: Maximum number of jobs to execute in a second.</li>
+ * </ul>
+ *
+ * @exports RateLimiter
+ * @param {Object} options Parameters
+ * @constructor
+ */
+function RateLimiter(options) {
+  this.perSecond = options.perSecond
+  this._lastExecuted = null
+  this._pendingJobs = []
+  this._timerID = null
+}
+
+module.exports = RateLimiter
+
+/**
+ * Enqueue a job to be run. Queued jobs are executed FIFO, no faster than the
+ * set rate limit.
+ * The job function is expected to <em>immediately</em> perform the
+ * rate-limited action (e.g. making an HTTP request). If the job function waits
+ * before performing the rate-limited action, it may cause requests to
+ * temporarily spike above the rate limit. (As long as each job function
+ * performs no more than one action, though, the rate will on average stay
+ * below the limit.)
+ *
+ * @param {Function} job Function to be rate-limited.
+ */
+RateLimiter.prototype.enqueue = function(job) {
+  var now = +new Date
+  if (this._timerID || now - this._lastExecuted < 1000/this.perSecond) {
+    this._pendingJobs.push(job)
+    if (!this._timerID) {
+      var nextExecutionMs = this._lastExecuted + 1000/this.perSecond - now
+      this._timerID = setTimeout(this._processPendingJobs.bind(this), nextExecutionMs)
+    }
+  } else {
+    this._lastExecuted = now
+    // Call the job in the following tick to prevent potential issues with
+    // exception handling (if we were to call job() directly, it might throw an
+    // exception, causing different application behaviour than if it were
+    // executed in a setTimeout() callback).
+    setTimeout(job)
+  }
+}
+
+RateLimiter.prototype._processPendingJobs = function() {
+  var now = +new Date
+  var job = this._pendingJobs.shift()
+  // If there are still more jobs, schedule another tick.
+  if (this._pendingJobs.length)
+    this._timerID = setTimeout(this._processPendingJobs.bind(this), 1000/this.perSecond)
+  else
+    this._timerID = null
+  this._lastExecuted = now
+  job()
+}


### PR DESCRIPTION
Just to be safe :) The cache handler should take care of rate limiting most of the time, but this guarantees that the overall query rate stays below the 30/sec limit.
