### PR TITLE
Parse CDATA

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -308,6 +308,14 @@ Client.prototype.parse = function (xml, cb) {
     parents[parents.length - 1].result[currentTag.name] = text
   })
 
+  parser.on('cdata', function (text) {
+    if (current.cdata == null) {
+      current.cdata = text
+    } else {
+      current.cdata += text
+    }
+  })
+
   if (xml.pipe) {
     xml.pipe(parser)
   } else {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/eveonline.js",
   "dependencies": {
-    "sax": "0.4.x"
+    "sax": "0.5.x"
   },
   "repository": {
     "type":"git",

--- a/test/cdata.json
+++ b/test/cdata.json
@@ -1,0 +1,8 @@
+{
+  "notifications": {
+    "9001": {
+      "notificationID": "9001",
+      "cdata": "applicationText: 'herp\r\n  derp'\r\n  charID: 9002\r\n  corpID: 1337\r\n"
+    }
+  }
+}

--- a/test/cdata.json
+++ b/test/cdata.json
@@ -2,7 +2,7 @@
   "notifications": {
     "9001": {
       "notificationID": "9001",
-      "cdata": "applicationText: 'herp\r\n  derp'\r\n  charID: 9002\r\n  corpID: 1337\r\n"
+      "cdata": "applicationText: 'herp derp' charID: 9002 corpID: 1337"
     }
   }
 }

--- a/test/cdata.xml
+++ b/test/cdata.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<eveapi version="2">
+	<result>
+    <rowset name="notifications" key="notificationID" columns="notificationID">
+      <row notificationID="9001">
+        <![CDATA[applicationText: 'herp
+  derp'
+  charID: 9002
+  corpID: 1337
+]]>
+      </row>
+    </rowset>
+	</result>
+</eveapi>

--- a/test/cdata.xml
+++ b/test/cdata.xml
@@ -3,11 +3,7 @@
 	<result>
     <rowset name="notifications" key="notificationID" columns="notificationID">
       <row notificationID="9001">
-        <![CDATA[applicationText: 'herp
-  derp'
-  charID: 9002
-  corpID: 1337
-]]>
+        <![CDATA[applicationText: 'herp derp' charID: 9002 corpID: 1337]]>
       </row>
     </rowset>
 	</result>

--- a/test/client.js
+++ b/test/client.js
@@ -150,6 +150,20 @@ test('#parse() can parse mutli-keyed rowsets', function (done) {
   })
 })
 
+test('#parse() can parse cdata', function (done) {
+  var client = new Client()
+
+  fs.readFile(__dirname + '/cdata.xml', function (err, xml) {
+    fs.readFile(__dirname + '/cdata.json', function (err, json) {
+      client.parse(xml, function (err, result) {
+        assert.ifError(err)
+        assert.deepEqual(result, JSON.parse(json))
+        done()
+      })
+    })
+  })
+})
+
 test('#parse() can parse error response', function (done){
   var client = new Client()
 


### PR DESCRIPTION
Not sure if it's ready for a merge yet, but it does pass the tests.

Some concerns:
- [lib/client.js#L312-L316](https://github.com/eve-apps/eveonlinejs/blob/b8cb30ab031981272d619c12850f085667d6cfd4/lib/client.js#L312-L316)
  - I wasn't sure where to put the cdata, so I went with what seemed to be the most faithful to the original XML structure
  - What if a tag has a `cdata` attribute? Would this overwrite that?
  - The null check is to concatenate all the `CDATA` because according to the [sax docs](https://github.com/isaacs/sax-js#events):
    
    > Since `<![CDATA[` blocks can get quite large, this event may fire multiple times for a single block, if it is broken up into multiple `write()`s
    
    Although it's probably unnecessary here.
- [test/cdata.json#L5](https://github.com/eve-apps/eveonlinejs/blob/b8cb30ab031981272d619c12850f085667d6cfd4/test/cdata.json#L5): the carriage returns here might cause the tests to fail on platforms other than Windows ~~(untested)~~ **edit**: well, it's tested now. See the Travis build fail below.
